### PR TITLE
Open settings when no active provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ NuneTV is a Kotlin-based Android TV application built with the Leanback library 
 
 ## Provider Management
 
+- On first launch, the provider settings screen opens automatically so you can configure your first IPTV provider.
 - Press the **Menu** or **Settings** button on the Android TV remote while on the home screen to launch the provider settings screen.
 - Enter the XStream Codes portal URL, username, and password. Optional M3U and EPG URLs can be supplied to augment the catalogue.
 - Use **Test Connection** to validate credentials, then **Save Provider** and **Activate Provider** to refresh the content library.

--- a/app/src/main/java/com/nunetv/iptv/activities/MainActivity.kt
+++ b/app/src/main/java/com/nunetv/iptv/activities/MainActivity.kt
@@ -94,6 +94,9 @@ class MainActivity : FragmentActivity(), MainBrowseFragment.Callbacks, ChannelDe
     override fun onResume() {
         super.onResume()
         viewModel.refreshFromStorage()
+        if (viewModel.activeProvider.value == null) {
+            startActivity(Intent(this, SettingsActivity::class.java))
+        }
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -54,7 +54,7 @@ This guide walks you through configuring and launching the NuneTV Android TV IPT
 
 ## Provider Configuration
 
-1. Open the app and press the **Menu** or **Settings** button on the remote to launch the provider settings screen.
+1. Open the app. On first launch, the provider settings screen opens automatically. You can also press the **Menu** or **Settings** button on the remote at any time to return to it.
 2. Enter the XStream Codes portal URL, username, password, and optional M3U/EPG URLs.
 3. Use **Test Connection** to validate the credentials.
 4. Save the provider and activate it to refresh the content catalogue.


### PR DESCRIPTION
## Summary
- start the settings activity automatically when no provider is configured
- document the first-launch provider setup flow in the README and setup guide

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c27bb620832ea4cbdd4c4c550616