### PR TITLE
Fix leanback search provider import and toast message

### DIFF
--- a/app/src/main/java/com/nunetv/iptv/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/nunetv/iptv/activities/SettingsActivity.kt
@@ -87,7 +87,7 @@ class SettingsActivity : FragmentActivity() {
             when (state) {
                 TestState.Loading -> Toast.makeText(this, R.string.status_testing, Toast.LENGTH_SHORT).show()
                 TestState.Success -> Toast.makeText(this, R.string.status_success, Toast.LENGTH_SHORT).show()
-                is TestState.Error -> Toast.makeText(this, state.message ?: getString(R.string.status_failed), Toast.LENGTH_SHORT).show()
+                is TestState.Error -> Toast.makeText(this, state.message, Toast.LENGTH_SHORT).show()
                 TestState.Idle -> Unit
             }
         }

--- a/app/src/main/java/com/nunetv/iptv/fragments/ChannelSearchFragment.kt
+++ b/app/src/main/java/com/nunetv/iptv/fragments/ChannelSearchFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.content.Intent
 import androidx.core.content.ContextCompat
 import androidx.leanback.app.SearchSupportFragment
+import androidx.leanback.app.SearchSupportFragment.SearchResultProvider
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.HeaderItem
 import androidx.leanback.widget.ListRow


### PR DESCRIPTION
## Summary
- import the Leanback SearchResultProvider interface explicitly so ChannelSearchFragment compiles
- remove an unnecessary Elvis operator on the non-null TestState.Error message to avoid a Kotlin compiler error when showing the toast

## Testing
- `./gradlew assembleDebug --console=plain` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ddcbaaf8832eb2b3d0e9036aed5e